### PR TITLE
Adding missing service account

### DIFF
--- a/nats-server/nats-server-with-auth.yml
+++ b/nats-server/nats-server-with-auth.yml
@@ -248,3 +248,32 @@ spec:
         ports:
         - containerPort: 7777
           name: metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nats-server
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nats-server
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nats-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nats-server
+subjects:
+- kind: ServiceAccount
+  name: nats-server
+  namespace: default


### PR DESCRIPTION
Copied missing service account from nats-server-with-auth-and-tls.yml